### PR TITLE
Fix cedilla mapping

### DIFF
--- a/plugin/deadkeys.vim
+++ b/plugin/deadkeys.vim
@@ -143,7 +143,7 @@ function! DeadKeys()
 
 	" cedilla
 	imap ,c ç
-	imap ^C Ç
+	imap ,C Ç
 
 endfunction "deadkeys()
 


### PR DESCRIPTION
The mapping for Ç is `^C`, but is being unbound as if it were `,C`. This produces an error when calling DeadKeysOff().

This change fixes the error by making Ç consistent with ç, as was probably intended.